### PR TITLE
Ignore temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@ target/
 
 *.class
 
+# Emacs temporary files
+\#*#
+.#*
+*~
+
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 


### PR DESCRIPTION
This commit updates the `.gitignore` file in the root of the working directory to ignore Emacs temporary files.